### PR TITLE
Create endpoint for fetching all milestones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 yarn-error.log
+
 # client
 client/dist
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }

--- a/client/src/redux/helpers.js
+++ b/client/src/redux/helpers.js
@@ -1,8 +1,0 @@
-export const getCurrentTeam = state =>
-  state.teams.entities.find(t => t.id === state.teams.current);
-
-export const getGoals = state => {
-  const team = getCurrentTeam(state);
-
-  return team ? team.goals : undefined;
-};

--- a/server/server/controllers/constants.js
+++ b/server/server/controllers/constants.js
@@ -1,0 +1,7 @@
+const API_URL = 'https://api.clubhouse.io/api/v2';
+const API_KEY = process.env.CLUBHOUSE_API_KEY;
+
+module.exports = {
+  API_URL,
+  API_KEY,
+};

--- a/server/server/controllers/helpers.js
+++ b/server/server/controllers/helpers.js
@@ -1,0 +1,8 @@
+const whitelistMilestone = milestone => ({
+  id: milestone.id,
+  name: milestone.name,
+});
+
+module.exports = {
+  whitelistMilestone,
+};

--- a/server/server/controllers/index.js
+++ b/server/server/controllers/index.js
@@ -1,0 +1,5 @@
+const milestones = require('./milestones');
+
+module.exports = {
+  milestones,
+};

--- a/server/server/controllers/milestones.js
+++ b/server/server/controllers/milestones.js
@@ -1,0 +1,28 @@
+const request = require('request-promise');
+const { whitelistMilestone } = require('./helpers');
+const { API_URL, API_KEY } = require('./constants');
+
+const list = (req, res, next) => {
+  const qs = {
+    token: API_KEY,
+    page_size: 25,
+    query: req.query.query,
+    next: req.query.next,
+  };
+
+  const options = {
+    uri: `${API_URL}/milestones`,
+    qs,
+    json: true,
+  };
+
+  return request(options)
+    .then((milestones = []) => {
+      res.status(200).send({
+        data: milestones.map(whitelistMilestone),
+      });
+    })
+    .catch(next);
+};
+
+module.exports = { list };

--- a/server/server/routes/index.js
+++ b/server/server/routes/index.js
@@ -1,7 +1,11 @@
+const milestonesController = require('../controllers').milestones;
+
 module.exports = app => {
   app.get('/api', (req, res) =>
     res.status(200).send({
-      message: 'Welcome to Gruva API!'
-    })
+      message: 'Welcome to Gruva API!',
+    }),
   );
+
+  app.get('/milestones', milestonesController.list);
 };


### PR DESCRIPTION
This creates a `/milestones` API endpoint that we can call from the frontend. After fetching the data we tidy the data up with a `whitelistMilestone` function. This is so that we return only the data the frontend app needs, for now the milestone id and name.